### PR TITLE
Batch mapping edits for missing items

### DIFF
--- a/mappings.edits.json
+++ b/mappings.edits.json
@@ -1,5 +1,13 @@
 {
   "$schema": "https://cdn.jsdelivr.net/gh/eliasbenb/PlexAniBridge-Mappings/mappings.schema.json",
+  "376": {
+    "mal_id": 376,
+    "tvdb_id": 75941,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 42671,
+    "imdb_id": "tt0480489"
+  },
   "384": {
     "mal_id": 384,
     "tvdb_id": 78916,
@@ -154,6 +162,16 @@
   "1803": {
     "tvdb_epoffset": 24
   },
+  "1841": {
+    "mal_id": 933,
+    "tvdb_id": 80082,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 45286
+  },
+  "1911": {
+    "tvdb_epoffset": 9
+  },
   "1935": {
     "anidb_id": 1729,
     "mal_id": 1935,
@@ -189,6 +207,14 @@
   "2066": {
     "tvdb_epoffset": 9
   },
+  "2265": {
+    "tvdb_id": 72499,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 1857,
+    "tmdb_show_id": 4269,
+    "imdb_id": "tt0092106"
+  },
   "2268": {
     "tvdb_id": 72499,
     "tvdb_season": -1,
@@ -196,8 +222,33 @@
     "tmdb_show_id": 4269,
     "imdb_id": "tt0086817"
   },
+  "2359": {
+    "anidb_id": 3194,
+    "mal_id": 2359,
+    "tmdb_movie_id": 48624,
+    "imdb_id": "tt0108461"
+  },
   "2466": {
     "tvdb_epoffset": 1
+  },
+  "2593": {
+    "mal_id": 2593,
+    "tvdb_id": 82099,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 23150,
+    "imdb_id": "tt1155650"
+  },
+  "2724": {
+    "mal_id": 2724,
+    "tmdb_movie_id": 283069,
+    "imdb_id": "tt3066198"
+  },
+  "2755": {
+    "anidb_id": 4579,
+    "mal_id": 2755,
+    "tmdb_movie_id": 84488,
+    "imdb_id": "tt0065588"
   },
   "2819": {
     "tvdb_id": 138211,
@@ -206,12 +257,44 @@
   "2829": {
     "tvdb_id": 261387
   },
+  "2981": {
+    "anidb_id": 3619,
+    "mal_id": 2981,
+    "tmdb_movie_id": 53064,
+    "imdb_id": "tt0930902"
+  },
+  "2994": {
+    "mal_id": 2994,
+    "tvdb_id": 79481,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": [
+      51482,
+      68555
+    ],
+    "imdb_id": [
+      "tt3355694",
+      "tt3355698"
+    ]
+  },
   "3021": {
     "tvdb_id": 82981
+  },
+  "3038": {
+    "anidb_id": 3683,
+    "mal_id": 3038,
+    "tmdb_movie_id": 85398,
+    "imdb_id": "tt0064961"
   },
   "3154": {
     "tvdb_epoffset": 1,
     "tvdb_season": 0
+  },
+  "3220": {
+    "anidb_id": 3289,
+    "mal_id": 3220,
+    "tmdb_movie_id": 64847,
+    "imdb_id": "tt0071203"
   },
   "3270": {
     "mal_id": 3270,
@@ -221,8 +304,63 @@
     "tmdb_show_id": 23475,
     "imdb_id": "tt0487183"
   },
+  "3782": {
+    "mal_id": 3782,
+    "tvdb_id": 82099,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 23151,
+    "imdb_id": "tt1155651"
+  },
+  "3783": {
+    "mal_id": 3783,
+    "tvdb_id": 82099,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 2,
+    "tmdb_movie_id": 23153,
+    "imdb_id": "tt1155652"
+  },
+  "3901": {
+    "mal_id": 3901,
+    "tvdb_id": 80421,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 34121,
+    "imdb_id": "tt1334722"
+  },
+  "4059": {
+    "mal_id": 4059,
+    "tvdb_id": 80644,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 24835
+  },
+  "4182": {
+    "mal_id": 4182,
+    "tvdb_id": 80042,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 31718,
+    "imdb_id": "tt0995941"
+  },
   "4197": {
     "tvdb_season": 2
+  },
+  "4280": {
+    "mal_id": 4280,
+    "tvdb_id": 82099,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 3,
+    "tmdb_movie_id": 23154,
+    "imdb_id": "tt1233474"
+  },
+  "4282": {
+    "mal_id": 4282,
+    "tvdb_id": 82099,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 4,
+    "tmdb_movie_id": 23155,
+    "imdb_id": "tt1278060"
   },
   "4314": {
     "tvdb_epoffset": 12
@@ -241,14 +379,111 @@
   "5152": {
     "tvdb_epoffset": 22
   },
+  "5204": {
+    "mal_id": 5204,
+    "tvdb_id": 82099,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 5,
+    "tmdb_movie_id": 23166,
+    "imdb_id": "tt1343089"
+  },
+  "5205": {
+    "mal_id": 5205,
+    "tvdb_id": 82099,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 6,
+    "tmdb_movie_id": 23167,
+    "imdb_id": "tt1345776"
+  },
   "6165": {
     "tvdb_epoffset": 13
+  },
+  "6351": {
+    "mal_id": 6351,
+    "tvdb_id": 80644,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_show_id": 24835
+  },
+  "6624": {
+    "mal_id": 6624,
+    "tvdb_id": 82099,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 61666,
+    "imdb_id": "tt9277666"
   },
   "6714": {
     "tvdb_epoffset": 18
   },
+  "6772": {
+    "mal_id": 6772,
+    "tvdb_id": 179791,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 55426,
+    "imdb_id": "tt1663145"
+  },
+  "6793": {
+    "mal_id": 6793,
+    "tvdb_id": 83996,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 50712
+  },
+  "6811": {
+    "tvdb_season": 7
+  },
+  "6862": {
+    "mal_id": 6862,
+    "tvdb_id": 87501,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 18,
+    "tmdb_show_id": 42253
+  },
+  "6954": {
+    "mal_id": 6954,
+    "tvdb_id": 82099,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "imdb_id": "tt3868344"
+  },
+  "7014": {
+    "mal_id": 7014,
+    "tmdb_movie_id": 115969,
+    "imdb_id": "tt1686865"
+  },
+  "7338": {
+    "mal_id": 7338,
+    "tvdb_id": 80042,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 31718,
+    "imdb_id": "tt0995941"
+  },
   "7897": {
     "tvdb_epoffset": 1
+  },
+  "8100": {
+    "mal_id": 8100,
+    "tmdb_movie_id": 73529,
+    "imdb_id": "tt1754177"
+  },
+  "8408": {
+    "mal_id": 8408,
+    "tvdb_id": 133341,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 42410,
+    "imdb_id": "tt1584000"
+  },
+  "8514": {
+    "mal_id": 8514,
+    "tvdb_id": 179791,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 55430,
+    "imdb_id": "tt1679583"
   },
   "8861": {
     "anidb_id": 7656,
@@ -259,14 +494,119 @@
     "tmdb_show_id": 68005,
     "imdb_id": "tt1743681"
   },
+  "8888": {
+    "mal_id": 8888,
+    "tvdb_id": 79525,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 6,
+    "tmdb_movie_id": 185526,
+    "imdb_id": "tt3354096"
+  },
+  "9252": {
+    "mal_id": 9252,
+    "tvdb_id": 179791,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_movie_id": 55431,
+    "imdb_id": "tt1726641"
+  },
+  "9260": {
+    "mal_id": 9260,
+    "tvdb_id": 102261,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 357786,
+    "imdb_id": "tt3138698"
+  },
+  "9366": {
+    "mal_id": 9366,
+    "tvdb_id": 148151,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 65648
+  },
+  "9465": {
+    "mal_id": 9465,
+    "tvdb_id": 179791,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 3,
+    "tmdb_movie_id": 55435,
+    "imdb_id": "tt1753855"
+  },
+  "9724": {
+    "mal_id": 9724,
+    "tvdb_id": 179791,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 4,
+    "tmdb_movie_id": 55437,
+    "imdb_id": "tt1809274"
+  },
+  "9734": {
+    "mal_id": 9734,
+    "tvdb_id": 87501,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 16,
+    "tmdb_show_id": 42253
+  },
   "9744": {
     "tvdb_epoffset": 2
+  },
+  "9931": {
+    "tmdb_movie_id": 379152,
+    "imdb_id": "tt0829187"
   },
   "10016": {
     "tvdb_epoffset": 2
   },
+  "10020": {
+    "mal_id": 10020,
+    "tvdb_id": 194961,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 56353,
+    "imdb_id": "tt1751305"
+  },
+  "10067": {
+    "mal_id": 10067,
+    "tvdb_id": 150471,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 42942
+  },
+  "10092": {
+    "mal_id": 10092,
+    "tvdb_id": 179791,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 5,
+    "tmdb_movie_id": 55438,
+    "imdb_id": "tt1865375"
+  },
+  "10119": {
+    "mal_id": 10119,
+    "tvdb_id": 173271,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 36697,
+    "imdb_id": "tt1694038"
+  },
   "10177": {
     "tvdb_season": 0
+  },
+  "10218": {
+    "mal_id": 10218,
+    "tvdb_id": 425148,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 113082,
+    "imdb_id": "tt2210479"
+  },
+  "10294": {
+    "mal_id": 10294,
+    "tvdb_id": 251622,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 179923,
+    "imdb_id": "tt3565112"
   },
   "10471": {
     "mal_id": 10471,
@@ -281,8 +621,164 @@
   "10502": {
     "tvdb_epoffset": 3
   },
+  "10592": {
+    "mal_id": 10592,
+    "tvdb_id": 78953,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 314102,
+    "tmdb_show_id": 42676,
+    "imdb_id": "tt6423446"
+  },
+  "10624": {
+    "mal_id": 10624,
+    "tmdb_movie_id": 73530,
+    "imdb_id": "tt2048804"
+  },
+  "10713": {
+    "mal_id": 10713,
+    "tvdb_id": 251622,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 179930,
+    "imdb_id": "tt3565136"
+  },
+  "10714": {
+    "mal_id": 10714,
+    "tvdb_id": 251622,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 2,
+    "tmdb_movie_id": 179931,
+    "imdb_id": "tt3565148"
+  },
+  "10715": {
+    "mal_id": 10715,
+    "tvdb_id": 251622,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 3,
+    "tmdb_movie_id": 179932,
+    "imdb_id": "tt3565158"
+  },
+  "10716": {
+    "mal_id": 10716,
+    "tvdb_id": 251622,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 4,
+    "tmdb_movie_id": 179933,
+    "imdb_id": "tt3565160"
+  },
+  "10717": {
+    "mal_id": 10717,
+    "tvdb_id": 251622,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 5,
+    "tmdb_movie_id": 179934,
+    "imdb_id": "tt3565164"
+  },
+  "10739": {
+    "mal_id": 10739,
+    "tvdb_id": 188551,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 42421,
+    "imdb_id": "tt10145102"
+  },
+  "10863": {
+    "mal_id": 10863,
+    "tvdb_id": 244061,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 42509
+  },
+  "10918": {
+    "mal_id": 10918,
+    "tvdb_id": 153881,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 387508
+  },
+  "11077": {
+    "mal_id": 11077,
+    "tvdb_id": 263688,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 115176,
+    "imdb_id": "tt2878716"
+  },
   "11313": {
     "tvdb_season": 0
+  },
+  "11553": {
+    "mal_id": 11553,
+    "tvdb_id": 83277,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 4,
+    "tmdb_show_id": 42916
+  },
+  "11867": {
+    "tmdb_movie_id": 390539,
+    "imdb_id": "tt8339440"
+  },
+  "11977": {
+    "mal_id": 11977,
+    "tvdb_id": 219181,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 152042,
+    "imdb_id": "tt2205948"
+  },
+  "11979": {
+    "mal_id": 11979,
+    "tvdb_id": 219181,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 152044,
+    "imdb_id": "tt2194724"
+  },
+  "11981": {
+    "mal_id": 11981,
+    "tvdb_id": 219181,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_movie_id": 212162,
+    "imdb_id": "tt2457282"
+  },
+  "12015": {
+    "mal_id": 12015,
+    "tvdb_id": 246381,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 178592,
+    "imdb_id": "tt2507174"
+  },
+  "12017": {
+    "mal_id": 12017,
+    "tvdb_id": 246381,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 4,
+    "tmdb_movie_id": 258807,
+    "imdb_id": "tt3204012"
+  },
+  "12053": {
+    "mal_id": 12053,
+    "tmdb_movie_id": 122662,
+    "imdb_id": "tt2423504"
+  },
+  "12113": {
+    "mal_id": 12113,
+    "tvdb_id": 425148,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 118412,
+    "imdb_id": "tt2358911"
+  },
+  "12115": {
+    "mal_id": 12115,
+    "tvdb_id": 425148,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_movie_id": 144288,
+    "imdb_id": "tt2358913"
   },
   "12231": {
     "tvdb_epoffset": 24
@@ -290,8 +786,38 @@
   "12437": {
     "tvdb_epoffset": 1
   },
+  "12565": {
+    "mal_id": 12565,
+    "tvdb_id": 251047,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_show_id": 43295,
+    "imdb_id": "tt8047180"
+  },
+  "12867": {
+    "mal_id": 12867,
+    "tmdb_movie_id": 1220676
+  },
   "12907": {
     "tvdb_id": 269157
+  },
+  "13117": {
+    "mal_id": 13117,
+    "tvdb_id": 151281,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_movie_id": 297676,
+    "tmdb_show_id": 44318,
+    "imdb_id": "tt3856638"
+  },
+  "13119": {
+    "mal_id": 13119,
+    "tvdb_id": 151281,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 3,
+    "tmdb_movie_id": 380770,
+    "tmdb_show_id": 44318,
+    "imdb_id": "tt5825186"
   },
   "13171": {
     "tvdb_epoffset": 1
@@ -310,11 +836,30 @@
     "tmdb_show_id": 56402,
     "imdb_id": "tt1579911"
   },
+  "13357": {
+    "mal_id": 13357,
+    "tvdb_id": 254653,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 45950
+  },
+  "13851": {
+    "mal_id": 13851,
+    "tvdb_id": 81831,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 6,
+    "tmdb_show_id": 34742
+  },
   "13863": {
     "tvdb_epoffset": 3
   },
   "14347": {
     "tvdb_epoffset": 1
+  },
+  "14407": {
+    "mal_id": 14407,
+    "tmdb_movie_id": 212153,
+    "imdb_id": "tt3198652"
   },
   "14519": {
     "tvdb_season": 2
@@ -330,14 +875,92 @@
     "tmdb_show_id": 65503,
     "imdb_id": "tt2398674"
   },
+  "15197": {
+    "mal_id": 15197,
+    "tvdb_id": 79525,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 7,
+    "tmdb_movie_id": 212161,
+    "imdb_id": "tt3354254"
+  },
+  "15199": {
+    "mal_id": 15199,
+    "tvdb_id": 79525,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 8,
+    "tmdb_movie_id": 347200,
+    "imdb_id": "tt3354302"
+  },
+  "15201": {
+    "mal_id": 15201,
+    "tvdb_id": 79525,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 9,
+    "tmdb_movie_id": 347187,
+    "imdb_id": "tt3354306"
+  },
+  "15335": {
+    "tvdb_epoffset": 6
+  },
+  "15617": {
+    "mal_id": 15617,
+    "tvdb_id": 259653,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 53356
+  },
+  "15687": {
+    "mal_id": 15687,
+    "tvdb_id": 261862,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 10,
+    "tmdb_show_id": 45501
+  },
+  "16001": {
+    "mal_id": 16001,
+    "tvdb_id": 259647,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 45807,
+    "imdb_id": "tt2250034"
+  },
   "16033": {
     "tvdb_season": 0
+  },
+  "16774": {
+    "mal_id": 16774,
+    "tvdb_id": 265113,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 46798,
+    "imdb_id": "tt3498252"
+  },
+  "16934": {
+    "mal_id": 16934,
+    "tvdb_id": 261862,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 45501,
+    "imdb_id": "tt2321542"
+  },
+  "17187": {
+    "mal_id": 17187,
+    "tvdb_id": 293491,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 196750,
+    "tmdb_show_id": 62070,
+    "imdb_id": "tt2636124"
   },
   "17705": {
     "tvdb_season": 1
   },
   "17727": {
     "tvdb_season": 2
+  },
+  "17787": {
+    "mal_id": 17787,
+    "tmdb_movie_id": 828883
   },
   "18121": {
     "mal_id": 18121,
@@ -346,6 +969,40 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 53020,
     "imdb_id": "tt2390066"
+  },
+  "18857": {
+    "mal_id": 18857,
+    "tvdb_id": 194961,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 20,
+    "tmdb_show_id": 56353
+  },
+  "19191": {
+    "mal_id": 19191,
+    "tvdb_id": 293491,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_movie_id": 212168,
+    "tmdb_show_id": 62070,
+    "imdb_id": "tt3017864"
+  },
+  "19193": {
+    "mal_id": 19193,
+    "tvdb_id": 293491,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 3,
+    "tmdb_movie_id": 240341,
+    "tmdb_show_id": 62070,
+    "imdb_id": "tt3579524"
+  },
+  "19195": {
+    "mal_id": 19195,
+    "tvdb_id": 293491,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 4,
+    "tmdb_movie_id": 279254,
+    "tmdb_show_id": 62070,
+    "imdb_id": "tt4016942"
   },
   "20181": {
     "mal_id": 15061,
@@ -366,6 +1023,19 @@
     "tmdb_show_id": 53020,
     "imdb_id": "null"
   },
+  "20450": {
+    "mal_id": 21201,
+    "tvdb_id": 262856,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 53020,
+    "imdb_id": "tt2390066"
+  },
+  "20500": {
+    "mal_id": 20969,
+    "tmdb_movie_id": 239526,
+    "imdb_id": "tt2936864"
+  },
   "20502": {
     "tvdb_epoffset": 2
   },
@@ -375,8 +1045,47 @@
   "20505": {
     "tvdb_epoffset": 1
   },
+  "20511": {
+    "mal_id": 29855,
+    "tmdb_movie_id": 347182,
+    "imdb_id": "tt7230298"
+  },
+  "20572": {
+    "mal_id": 21659,
+    "tvdb_id": 272074,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 60728,
+    "imdb_id": "tt3114390"
+  },
+  "20691": {
+    "mal_id": 23775,
+    "tvdb_id": 267440,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 13,
+    "tmdb_movie_id": 379088,
+    "imdb_id": "tt3646944"
+  },
+  "20692": {
+    "mal_id": 23777,
+    "tvdb_id": 267440,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 17,
+    "tmdb_movie_id": 330081,
+    "imdb_id": "tt3646946"
+  },
   "20715": {
     "tvdb_epoffset": 2
+  },
+  "20736": {
+    "mal_id": 21473,
+    "tmdb_movie_id": 297189,
+    "imdb_id": "tt3898504"
+  },
+  "20737": {
+    "mal_id": 24543,
+    "tmdb_movie_id": 332169,
+    "imdb_id": "tt4331400"
   },
   "20742": {
     "mal_id": 23135,
@@ -385,8 +1094,54 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 67627
   },
+  "20760": {
+    "tvdb_epoffset": 9
+  },
+  "20763": {
+    "mal_id": 24919,
+    "tvdb_id": 272317,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 24,
+    "tmdb_movie_id": 296918,
+    "imdb_id": "tt4219304"
+  },
+  "20764": {
+    "mal_id": 24921,
+    "tvdb_id": 272317,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 25,
+    "tmdb_movie_id": 357397,
+    "imdb_id": "tt5332274"
+  },
+  "20768": {
+    "mal_id": 25015,
+    "tvdb_id": 272697,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 13,
+    "tmdb_movie_id": 311056,
+    "imdb_id": "tt4531412"
+  },
+  "20769": {
+    "mal_id": 24991,
+    "tvdb_id": 278155,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 60808
+  },
   "20778": {
     "tvdb_epoffset": 14
+  },
+  "20779": {
+    "mal_id": 23385,
+    "tvdb_id": 272697,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 5,
+    "tmdb_show_id": 61695
+  },
+  "20791": {
+    "mal_id": 25537,
+    "tmdb_movie_id": 283984,
+    "imdb_id": "tt4054952"
   },
   "20794": {
     "mal_id": 15061,
@@ -396,6 +1151,19 @@
     "tmdb_show_id": 65503,
     "imdb_id": "tt2398674"
   },
+  "20802": {
+    "mal_id": 25687,
+    "tmdb_movie_id": 357400,
+    "imdb_id": "tt4307880"
+  },
+  "20805": {
+    "mal_id": 25729,
+    "tvdb_id": 195571,
+    "tvdb_season": 3,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 342126,
+    "imdb_id": "tt4691340"
+  },
   "20833": {
     "mal_id": 26395,
     "tvdb_id": 262856,
@@ -404,12 +1172,90 @@
     "tmdb_show_id": 53020,
     "imdb_id": "tt2390066"
   },
+  "20834": {
+    "mal_id": 22335,
+    "tvdb_id": 262856,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_show_id": 53020,
+    "imdb_id": "tt2390066"
+  },
+  "20835": {
+    "mal_id": 25161,
+    "tvdb_id": 81797,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 28,
+    "tmdb_show_id": 37854,
+    "tmdb_movie_id": 290271,
+    "imdb_id": "tt5098548"
+  },
+  "20837": {
+    "mal_id": 24151,
+    "tvdb_id": 279554,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 62602
+  },
+  "20869": {
+    "mal_id": 27633,
+    "tvdb_id": 279804,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 61379
+  },
+  "20882": {
+    "tvdb_epoffset": 8
+  },
+  "20884": {
+    "mal_id": 25303,
+    "tvdb_id": 278157,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 60863
+  },
+  "20889": {
+    "mal_id": 27601,
+    "tvdb_id": 261862,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 45501
+  },
+  "20959": {
+    "mal_id": 28077,
+    "tvdb_id": 275669,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 73394,
+    "imdb_id": "tt3399758"
+  },
+  "20963": {
+    "mal_id": 28675,
+    "tvdb_id": 272697,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 14,
+    "tmdb_movie_id": 333622,
+    "imdb_id": "tt4539114"
+  },
   "20985": {
     "mal_id": 23135,
     "tvdb_id": 282059,
     "tvdb_season": 2,
     "tvdb_epoffset": 0,
     "tmdb_show_id": 67627
+  },
+  "21077": {
+    "mal_id": 30206,
+    "tvdb_id": 280330,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 7,
+    "tmdb_show_id": 65332
+  },
+  "21132": {
+    "mal_id": 30458,
+    "tvdb_id": 281249,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 61374
   },
   "21136": {
     "mal_id": 30567,
@@ -419,6 +1265,14 @@
     "tmdb_show_id": 53020,
     "imdb_id": "tt2390066"
   },
+  "21186": {
+    "mal_id": 30709,
+    "tvdb_id": 262106,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_show_id": 62741,
+    "imdb_id": "tt2320220"
+  },
   "21301": {
     "mal_id": 31440,
     "tvdb_id": 262856,
@@ -427,6 +1281,13 @@
     "tmdb_show_id": 53020,
     "imdb_id": "tt2390066"
   },
+  "21303": {
+    "mal_id": 28405,
+    "tvdb_id": 283947,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 62110
+  },
   "21307": {
     "mal_id": 15061,
     "tvdb_id": 263310,
@@ -434,6 +1295,82 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 65503,
     "imdb_id": "tt2398674"
+  },
+  "21318": {
+    "mal_id": 31389,
+    "tvdb_id": 278626,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 61415,
+    "imdb_id": "tt3621796"
+  },
+  "21326": {
+    "mal_id": 31297,
+    "tvdb_id": 281249,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 61374
+  },
+  "21339": {
+    "mal_id": 31553,
+    "tvdb_id": 289679,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 63145,
+    "imdb_id": "tt4574736"
+  },
+  "21348": {
+    "mal_id": 35806,
+    "tvdb_id": 278157,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_show_id": 60863
+  },
+  "21399": {
+    "mal_id": 31757,
+    "tvdb_id": 102261,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 18,
+    "tmdb_show_id": 362584,
+    "imdb_id": "tt5084196"
+  },
+  "21400": {
+    "mal_id": 31758,
+    "tvdb_id": 102261,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 19,
+    "tmdb_show_id": 362585,
+    "imdb_id": "tt5084198"
+  },
+  "21416": {
+    "mal_id": 31772,
+    "tvdb_id": 293088,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 63926
+  },
+  "21437": {
+    "mal_id": 31668,
+    "tvdb_id": 262856,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 6,
+    "tmdb_show_id": 53020,
+    "imdb_id": "tt2390066"
+  },
+  "21438": {
+    "mal_id": 31608,
+    "tvdb_id": 262856,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 4,
+    "tmdb_show_id": 53020,
+    "imdb_id": "tt2390066"
+  },
+  "21483": {
+    "mal_id": 30714,
+    "tvdb_id": 289906,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 62255
   },
   "21513": {
     "mal_id": 32228,
@@ -450,6 +1387,22 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 67627
   },
+  "21579": {
+    "anidb_id": 10961,
+    "mal_id": 28755,
+    "tvdb_id": 79824,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 12,
+    "tmdb_movie_id": 347201,
+    "imdb_id": "tt4618398"
+  },
+  "21624": {
+    "mal_id": 32188,
+    "tvdb_id": 244061,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 6,
+    "tmdb_show_id": 42509
+  },
   "21648": {
     "mal_id": 32717,
     "tvdb_id": 309143,
@@ -458,6 +1411,16 @@
     "tmdb_show_id": 65929,
     "imdb_id": "tt9864008"
   },
+  "21718": {
+    "mal_id": 33049,
+    "tmdb_movie_id": 390634,
+    "imdb_id": "tt8091892"
+  },
+  "21719": {
+    "mal_id": 33050,
+    "tmdb_movie_id": 390635,
+    "imdb_id": "tt8092118"
+  },
   "21780": {
     "mal_id": 33142,
     "tvdb_id": 305089,
@@ -465,12 +1428,33 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 65942
   },
+  "21862": {
+    "mal_id": 33524,
+    "tvdb_id": 306153,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 65944
+  },
   "21891": {
     "mal_id": 33569,
     "tvdb_id": 305089,
     "tvdb_season": 0,
     "tvdb_epoffset": 11,
     "tmdb_show_id": 65942
+  },
+  "87486": {
+    "mal_id": 33929,
+    "tvdb_id": 305074,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 65930
+  },
+  "97818": {
+    "tvdb_id": 264522,
+    "tvdb_season": 3,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 50071,
+    "imdb_id": "tt2575728"
   },
   "98203": {
     "anidb_id": 12760,
@@ -480,6 +1464,20 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 70998
   },
+  "98502": {
+    "mal_id": 35145,
+    "tvdb_id": 318893,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 69291
+  },
+  "98524": {
+    "mal_id": 34855,
+    "tvdb_id": 318984,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 69285
+  },
   "98542": {
     "mal_id": 32717,
     "tvdb_id": 309143,
@@ -487,6 +1485,52 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 65929,
     "imdb_id": "tt9864008"
+  },
+  "98580": {
+    "mal_id": 35363,
+    "tvdb_id": 318893,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 69291
+  },
+  "98702": {
+    "mal_id": 34480,
+    "tvdb_id": 289909,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 3,
+    "tmdb_show_id": 62273
+  },
+  "98759": {
+    "mal_id": 32816,
+    "tvdb_id": 262856,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 8,
+    "tmdb_show_id": 53020,
+    "imdb_id": "tt2390066"
+  },
+  "98760": {
+    "mal_id": 32817,
+    "tvdb_id": 262856,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 10,
+    "tmdb_show_id": 53020,
+    "imdb_id": "tt2390066"
+  },
+  "98761": {
+    "mal_id": 34614,
+    "tvdb_id": 262856,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 12,
+    "tmdb_show_id": 53020,
+    "imdb_id": "tt2390066"
+  },
+  "98873": {
+    "mal_id": 34161,
+    "tvdb_id": 294002,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 9,
+    "tmdb_show_id": 64196,
+    "imdb_id": "tt6634906"
   },
   "99714": {
     "mal_id": 35843,
@@ -512,6 +1556,14 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 75778
   },
+  "100684": {
+    "mal_id": 36043,
+    "tvdb_id": 332771,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 74163,
+    "imdb_id": "tt7662364"
+  },
   "100784": {
     "mal_id": 36838,
     "tvdb_id": 79895,
@@ -519,6 +1571,17 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 57041,
     "imdb_id": "tt0988818"
+  },
+  "100815": {
+    "mal_id": 36999,
+    "tvdb_id": 102261,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 32,
+    "tmdb_show_id": 46195
+  },
+  "101034": {
+    "tmdb_movie_id": 495368,
+    "imdb_id": "tt7804226"
   },
   "101097": {
     "mal_id": 37178,
@@ -528,6 +1591,54 @@
     "tmdb_show_id": 78482,
     "imdb_id": "tt12209234"
   },
+  "101343": {
+    "mal_id": 37514,
+    "tvdb_id": 326109,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 526426,
+    "imdb_id": "tt10068158"
+  },
+  "101344": {
+    "mal_id": 37515,
+    "tvdb_id": 326109,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_movie_id": 526429,
+    "imdb_id": "tt10068544"
+  },
+  "101374": {
+    "anidb_id": 13972,
+    "mal_id": 37585,
+    "tvdb_id": 349733,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 99466,
+    "imdb_id": "tt14605648"
+  },
+  "101432": {
+    "mal_id": 37095,
+    "tvdb_id": 330139,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 75214
+  },
+  "101811": {
+    "mal_id": 34438,
+    "tvdb_id": 79525,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_movie_id": 477776,
+    "imdb_id": "tt8100900"
+  },
+  "101830": {
+    "mal_id": 37884,
+    "tvdb_id": 338455,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 76757,
+    "imdb_id": "tt20519280"
+  },
   "101981": {
     "anidb_id": 14112,
     "mal_id": 37281,
@@ -535,12 +1646,77 @@
     "tvdb_season": 1,
     "tvdb_epoffset": 0
   },
+  "102649": {
+    "mal_id": 37440,
+    "tvdb_id": 262090,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 12,
+    "tmdb_movie_id": 510242,
+    "imdb_id": "tt10443844"
+  },
+  "103276": {
+    "mal_id": 38085,
+    "tvdb_id": 353666,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 5,
+    "tmdb_movie_id": 637202,
+    "imdb_id": "tt9534948"
+  },
   "103870": {
     "mal_id": 39699,
     "tvdb_id": 422824,
     "tvdb_season": 1,
     "tvdb_epoffset": 0,
     "tmdb_show_id": 88490
+  },
+  "104174": {
+    "mal_id": 37492,
+    "tvdb_id": 339268,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 78102
+  },
+  "104243": {
+    "mal_id": 35994,
+    "tvdb_id": 344844,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 12,
+    "tmdb_show_id": 80477,
+    "imdb_id": "tt8670784"
+  },
+  "104382": {
+    "mal_id": 37441,
+    "tvdb_id": 262090,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 13,
+    "tmdb_movie_id": 559562,
+    "imdb_id": "tt11078434"
+  },
+  "104990": {
+    "mal_id": 37442,
+    "tvdb_id": 262090,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 14,
+    "tmdb_movie_id": 559566,
+    "imdb_id": "tt11078522"
+  },
+  "105893": {
+    "mal_id": 38699,
+    "tvdb_id": 305074,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 4,
+    "tmdb_show_id": 65930
+  },
+  "105934": {
+    "tmdb_movie_id": 570575,
+    "imdb_id": "tt18500586"
+  },
+  "106506": {
+    "mal_id": 37755,
+    "tvdb_id": 338455,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 4,
+    "tmdb_show_id": 76757
   },
   "108625": {
     "mal_id": 38804,
@@ -550,6 +1726,20 @@
     "tmdb_show_id": 78482,
     "imdb_id": "tt12209234"
   },
+  "108942": {
+    "mal_id": 39477,
+    "tvdb_id": 267440,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 23,
+    "tmdb_show_id": 1429
+  },
+  "108945": {
+    "mal_id": 39705,
+    "tvdb_id": 293088,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 8,
+    "tmdb_show_id": 63926
+  },
   "109260": {
     "mal_id": 39244,
     "tvdb_id": 245821,
@@ -557,6 +1747,11 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 107974,
     "imdb_id": "tt2549176"
+  },
+  "110261": {
+    "mal_id": 39991,
+    "tmdb_movie_id": 629014,
+    "imdb_id": "tt11803614"
   },
   "110270": {
     "anidb_id": 14969,
@@ -579,6 +1774,35 @@
     "tmdb_show_id": 107974,
     "imdb_id": "tt2549176"
   },
+  "111789": {
+    "mal_id": 40313,
+    "tmdb_movie_id": 631193,
+    "imdb_id": "tt11803654"
+  },
+  "111852": {
+    "mal_id": 40416,
+    "tvdb_id": 264663,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 3,
+    "tmdb_show_id": 46004,
+    "tmdb_movie_id": 685099,
+    "imdb_id": "tt12350118"
+  },
+  "112125": {
+    "mal_id": 40453,
+    "tvdb_id": 289882,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 3,
+    "tmdb_show_id": 62745
+  },
+  "113417": {
+    "anidb_id": 15274,
+    "mal_id": 40746,
+    "tvdb_id": 373728,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 95897
+  },
   "113425": {
     "anidb_id": 15277,
     "mal_id": 40750,
@@ -596,6 +1820,12 @@
     "tmdb_show_id": 78482,
     "imdb_id": "tt12209234"
   },
+  "114129": {
+    "tvdb_id": 79895,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 16,
+    "tmdb_movie_id": 732203
+  },
   "118465": {
     "anidb_id": 15561,
     "mal_id": 41946,
@@ -604,6 +1834,11 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 103409,
     "imdb_id": "tt13411814"
+  },
+  "119548": {
+    "tvdb_id": 321535,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2
   },
   "119939": {
     "tvdb_epoffset": 3
@@ -637,6 +1872,18 @@
     "tvdb_epoffset": 1,
     "tmdb_show_id": 902
   },
+  "124756": {
+    "mal_id": 38710,
+    "tvdb_id": 338455,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 1,
+    "tmdb_show_id": 76757,
+    "imdb_id": [
+      "tt20561132",
+      "tt20602938",
+      "tt20609980"
+    ]
+  },
   "127090": {
     "anidb_id": 15918,
     "mal_id": 44524,
@@ -645,6 +1892,13 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 114477,
     "imdb_id": "tt13628870"
+  },
+  "129464": {
+    "mal_id": 43253,
+    "tvdb_id": 383725,
+    "tvdb_season": 1,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 97915
   },
   "129591": {
     "tvdb_epoffset": 2
@@ -660,6 +1914,13 @@
     "tmdb_show_id": 10926,
     "imdb_id": "tt0367413"
   },
+  "130183": {
+    "mal_id": 35459,
+    "tvdb_id": 305074,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 2,
+    "tmdb_show_id": 65930
+  },
   "130402": {
     "mal_id": 46118,
     "tvdb_id": 393243,
@@ -668,12 +1929,45 @@
     "tmdb_show_id": 113780,
     "imdb_id": "tt13795144"
   },
+  "131773": {
+    "mal_id": 48614,
+    "tvdb_id": 390028,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 111255,
+    "imdb_id": "tt13248076"
+  },
+  "132096": {
+    "mal_id": [
+      48590,
+      49483
+    ],
+    "tvdb_id": 318893,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 8,
+    "tmdb_show_id": 69291
+  },
+  "137804": {
+    "mal_id": 49483,
+    "tvdb_id": 318893,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 24,
+    "tmdb_show_id": 69291
+  },
   "139409": {
     "mal_id": 49988,
     "tvdb_id": 400512,
     "tvdb_season": 0,
     "tvdb_epoffset": 0,
     "tmdb_show_id": 106055
+  },
+  "141534": {
+    "mal_id": 50360,
+    "tvdb_id": 371310,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 94664,
+    "imdb_id": "tt13293588"
   },
   "146310": {
     "anidb_id": 14582,
@@ -683,6 +1977,14 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 34114,
     "imdb_id": "tt0131160"
+  },
+  "146922": {
+    "mal_id": 52168,
+    "tvdb_id": 418364,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 0,
+    "tmdb_show_id": 196400,
+    "imdb_id": "tt15433166"
   },
   "152633": {
     "mal_id": 52745,
@@ -698,6 +2000,14 @@
     "tvdb_epoffset": 0,
     "tmdb_show_id": 211057,
     "imdb_id": "tt22445494"
+  },
+  "162314": {
+    "mal_id": 51535,
+    "tvdb_id": 267440,
+    "tvdb_season": 4,
+    "tvdb_epoffset": 29,
+    "tmdb_show_id": 1429,
+    "imdb_id": "tt2560140"
   },
   "169692": {
     "mal_id": 56704,
@@ -738,6 +2048,14 @@
     "tvdb_epoffset": 150,
     "tmdb_show_id": 5719,
     "imdb_id": "tt0796127"
+  },
+  "182469": {
+    "mal_id": 60022,
+    "tvdb_id": 81797,
+    "tvdb_season": 0,
+    "tvdb_epoffset": 56,
+    "tmdb_show_id": 37854,
+    "imdb_id": "tt33998607"
   },
   "182920": {
     "tvdb_epoffset": 26


### PR DESCRIPTION
Covers all reconcilable mappings for missing items with >25k members on anilist, plus other miscellaneous entries