### PR TITLE
Switch Wikidata SPARQL endpoint to qlever.dev to resolve 403 errors

### DIFF
--- a/update_mappings.py
+++ b/update_mappings.py
@@ -921,6 +921,10 @@ class AnimeIDCollector:
         self.logger.info("Scanning Wikidata")
 
         query = """
+        PREFIX wd: <http://www.wikidata.org/entity/>
+        PREFIX wdt: <http://www.wikidata.org/prop/direct/>
+        PREFIX p: <http://www.wikidata.org/prop/>
+        PREFIX ps: <http://www.wikidata.org/prop/statement/>
         SELECT DISTINCT ?item ?itemLabel ?anidbId ?anilistId ?malId ?imdbId ?plexId
             ?tmdbMovieId ?tmdbSeriesId ?tvdbMovieId ?tvdbSeriesId WHERE {
           ?item (p:P31/ps:P31/(wdt:P279*)) wd:Q1107.
@@ -937,9 +941,13 @@ class AnimeIDCollector:
         LIMIT 10000
         """
 
-        endpoint_url = "https://query.wikidata.org/sparql"
+        # https://query.wikidata.org/sparql (robots policy blocking usage)
+        endpoint_url = "https://qlever.dev/api/wikidata"
         params = {"query": query, "format": "json"}
-        headers = {"Accept": "application/sparql-results+json"}
+        headers = {
+            "Accept": "application/sparql-results+json",
+            "User-Agent": "PlexAniBridge-Mappings/2.1 (https://github.com/eliasbenb/PlexAniBridge-Mappings)",
+        }
 
         response = self.session.get(endpoint_url, params=params, headers=headers)
         response.raise_for_status()


### PR DESCRIPTION
The daily `Update Mappings` workflow has been failing with a `403 Forbidden` from `https://query.wikidata.org/sparql` since 2026-02-20. The Wikidata SPARQL endpoint blocks requests from GitHub Actions IP ranges.

Switches the endpoint to `https://qlever.dev/api/wikidata`, a SPARQL mirror of Wikidata that doesn't have this restriction, and adds the `PREFIX` declarations required by qlever.dev (inferred automatically on the Wikidata endpoint). Also adds a `User-Agent` header as best practice. This mirrors the fix applied in anibridge/anibridge-mappings@de285ed.

Tested by running the workflows on my fork v2 branch and configuring PlexAniBridge to use it. Should allow people to gracefully migrate to AniBridge when it is ready without losing mapping updates in the meantime.